### PR TITLE
Question for MERLev

### DIFF
--- a/Question for MERLev
+++ b/Question for MERLev
@@ -1,0 +1,3 @@
+You can make the controller detection “first” (example the red light is on at number 1) or turn off the constant flashing of the four red lights on the DualShock 3.
+
+If this possible Xerpi is degenerate from 2017-2021


### PR DESCRIPTION
You can make the controller detection “first” (example the red light is on at number 1) or turn off the constant flashing of the four red lights on the DualShock 3.

If this possible Xerpi is degenerate from 2017-2021